### PR TITLE
add databse context to helm chart

### DIFF
--- a/dda/env.py
+++ b/dda/env.py
@@ -24,3 +24,20 @@ class Env(Enum):
         if env_string is None:
             raise ValueError("DJANGO_ENV must be set.")
         return Env(env_string)
+
+
+def set_database_url() -> None:
+    """
+    Sets the DATABASE_URL environment variable to the construction
+    of a connection string from separated variables if the DATABASE_URL
+    variable is not already provided.
+    """
+    if os.environ.get("DATABASE_URL"):
+        return
+
+    db_host = os.environ.get("DB_HOST", "")
+    db_port = os.environ.get("DB_PORT", "")
+    db_user = os.environ.get("DB_USER", "")
+    db_password = os.environ.get("DB_PASSWORD", "")
+    db_name = os.environ.get("DB_NAME", "")
+    os.environ["DATABASE_URL"] = f"postgres://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"

--- a/dda/settings.py
+++ b/dda/settings.py
@@ -1,6 +1,7 @@
 import os
 import dj_database_url
 from dda.env import Env
+from dda.env import set_database_url
 
 
 # TODO: Allowed hosts?
@@ -72,7 +73,7 @@ TEMPLATES = [
     },
 ]
 
-
+set_database_url()
 DATABASES = {
     "default": dj_database_url.config(conn_max_age=600, conn_health_checks=True)
 }

--- a/deploy/dda-backend/Chart.yaml
+++ b/deploy/dda-backend/Chart.yaml
@@ -1,7 +1,5 @@
 apiVersion: v2
 name: dda-backend
-description: A Helm chart for Kubernetes
+description: Helm Chart for the DDA Backend Django service.
 type: application
 version: 0.1.0
-# Need to link to the docker image tag....
-appVersion: "0.1.0"

--- a/deploy/dda-backend/dev/secrets.yaml
+++ b/deploy/dda-backend/dev/secrets.yaml
@@ -1,2 +1,3 @@
 secretData:
   django_secret: test-secret-value
+  db_password: admin

--- a/deploy/dda-backend/dev/values.yaml
+++ b/deploy/dda-backend/dev/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: 977098986372.dkr.ecr.us-west-2.amazonaws.com/dda_backend
   pullPolicy: IfNotPresent
-  tag: "helm-chart-85a4227"
+  tag: "master-7ec1452"
 
 # Need to figure out how this works in a production
 # environment...
@@ -24,8 +24,6 @@ service:
 ingress:
   enabled: false
 
-resources: {}
-
 livenessProbe:
   httpGet:
     path: /v1/glb/health/full
@@ -41,15 +39,11 @@ autoscaling:
   maxReplicas: 5
   targetCPUUtilizationPercentage: 80
 
-volumes: []
-
-volumeMounts: []
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
-
 env:
   DJANGO_ENV: LOCAL
+
+pooler:
+  db_host: "host.docker.internal"
+  db_port: 5432
+  db_user: admin
+  db_name: dda_db

--- a/deploy/dda-backend/dev/values.yaml
+++ b/deploy/dda-backend/dev/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: 977098986372.dkr.ecr.us-west-2.amazonaws.com/dda_backend
   pullPolicy: IfNotPresent
-  tag: "master-7ec1452"
+  tag: "improved-helm-config-baa34aa"
 
 # Need to figure out how this works in a production
 # environment...
@@ -42,8 +42,11 @@ autoscaling:
 env:
   DJANGO_ENV: LOCAL
 
+migration:
+  enabled: true
+
 pooler:
-  db_host: "host.docker.internal"
+  db_host: "host.minikube.internal"
   db_port: 5432
   db_user: admin
   db_name: dda_db

--- a/deploy/dda-backend/templates/deployment.yaml
+++ b/deploy/dda-backend/templates/deployment.yaml
@@ -81,30 +81,37 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        # TODO: Specify a user for the app to connect to pgbouncer,
+        # then use a system app user for pgbouncer <-> remote database
         - name: pgbouncer
-            image: bitnami/pgbouncer:latest
-            env:
-              - name: POSTGRESQL_HOST
-                value: {{ .Values.pooler.db_host }}
-              - name: POSTGRESQL_PORT
-                value: {{ .Values.pooler.db_port }}
-              - name: POSTGRESQL_USERNAME
-                value: {{ .Values.pooler.db_user }}
-              - name: POSTGRESQL_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    name: db-secret
-                    key: password
-              - name: POSTGRESQL_DATABASE
-                value: {{ .Values.pooler.db_name }}
-              - name: POOL_MODE
-                value: "transaction"
-              - name: PGBOUNCER_MAX_CLIENT_CONN
-                value: {{ .Values.pooler.max_client_conn | default 100 }}
-              - name: PGBOUNCER_DEFAULT_POOL_SIZE
-                value: {{ .Values.pooler.default_pool_size | default 20 }}
-            ports:
-              - containerPort: 6432
+          image: bitnami/pgbouncer:latest
+          env:
+            - name: POSTGRESQL_HOST
+              value: "{{ .Values.pooler.db_host }}"
+            - name: POSTGRESQL_PORT
+              value: "{{ .Values.pooler.db_port }}"
+            - name: POSTGRESQL_USERNAME
+              value: "{{ .Values.pooler.db_user }}"
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+            - name: POSTGRESQL_DATABASE
+              value: "{{ .Values.pooler.db_name }}"
+            - name: PGBOUNCER_POOL_MODE
+              value: "transaction"
+            - name: PGBOUNCER_MAX_CLIENT_CONN
+              value: "{{ .Values.pooler.max_client_conn | default 100 }}"
+            - name: PGBOUNCER_DEFAULT_POOL_SIZE
+              value: "{{ .Values.pooler.default_pool_size | default 20 }}"
+          readinessProbe:
+            tcpSocket:
+              port: 6432
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          ports:
+            - containerPort: 6432
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/deploy/dda-backend/templates/deployment.yaml
+++ b/deploy/dda-backend/templates/deployment.yaml
@@ -38,15 +38,28 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           env:
             - name: "DJANGO_SECRET"
               valueFrom:
                 secretKeyRef:
-                  name: "django-secret"
+                  name: django-secret
                   key: django_secret_token
             - name: "DJANGO_ENV"
               value: "{{ .Values.env.DJANGO_ENV }}"
+            - name: "DB_HOST"
+              value: "localhost"
+            - name: "DB_PORT"
+              value: "6432"
+            - name: "DB_USER"
+              value: "{{ .Values.pooler.db_user }}"
+            - name: "DB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+            - name: "DB_NAME"
+              value: "{{ .Values.pooler.db_name }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
@@ -68,6 +81,30 @@ spec:
           volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+        - name: pgbouncer
+            image: bitnami/pgbouncer:latest
+            env:
+              - name: POSTGRESQL_HOST
+                value: {{ .Values.pooler.db_host }}
+              - name: POSTGRESQL_PORT
+                value: {{ .Values.pooler.db_port }}
+              - name: POSTGRESQL_USERNAME
+                value: {{ .Values.pooler.db_user }}
+              - name: POSTGRESQL_PASSWORD
+                valueFrom:
+                  secretKeyRef:
+                    name: db-secret
+                    key: password
+              - name: POSTGRESQL_DATABASE
+                value: {{ .Values.pooler.db_name }}
+              - name: POOL_MODE
+                value: "transaction"
+              - name: PGBOUNCER_MAX_CLIENT_CONN
+                value: {{ .Values.pooler.max_client_conn | default 100 }}
+              - name: PGBOUNCER_DEFAULT_POOL_SIZE
+                value: {{ .Values.pooler.default_pool_size | default 20 }}
+            ports:
+              - containerPort: 6432
       {{- with .Values.volumes }}
       volumes:
         {{- toYaml . | nindent 8 }}

--- a/deploy/dda-backend/templates/jobs.yaml
+++ b/deploy/dda-backend/templates/jobs.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.migration.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: django-database-migrate
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: migrate
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          command: ["python", "manage.py", "migrate"]
+          # Since this is a one-time job, we don't need pgbouncer, we can
+          # use the database directly.
+          env:
+            - name: "DJANGO_SECRET"
+              valueFrom:
+                secretKeyRef:
+                  name: django-secret
+                  key: django_secret_token
+            - name: "DJANGO_ENV"
+              value: "{{ .Values.env.DJANGO_ENV }}"
+            - name: "DB_HOST"
+              value: "{{ .Values.pooler.db_host }}"
+            - name: "DB_PORT"
+              value: "{{ .Values.pooler.db_port }}"
+            - name: "DB_USER"
+              value: "{{ .Values.pooler.db_user }}"
+            - name: "DB_PASSWORD"
+              valueFrom:
+                secretKeyRef:
+                  name: db-secret
+                  key: password
+            - name: "DB_NAME"
+              value: "{{ .Values.pooler.db_name }}"
+{{- end }}

--- a/deploy/dda-backend/templates/secrets.yaml
+++ b/deploy/dda-backend/templates/secrets.yaml
@@ -5,3 +5,11 @@ metadata:
 type: Opaque
 data:
   django_secret_token: {{ .Values.secretData.django_secret | b64enc }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: db-secret
+type: Opaque
+data:
+  password: {{ .Values.secretData.db_password | b64enc }}

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,15 @@
+import os
+from unittest.mock import patch
+from dda.env import set_database_url
+
+def test_set_database_url_assembles_connection_string() -> None:
+    mock_environ = {
+        "DB_HOST": "localhost",
+        "DB_PORT": "6432",
+        "DB_USER": "testuser",
+        "DB_PASSWORD": "testpassword",
+        "DB_NAME": "test_db"
+    }
+    with patch.dict(os.environ, mock_environ, clear=True):
+        set_database_url()
+        assert os.environ["DATABASE_URL"] == "postgres://testuser:testpassword@localhost:6432/test_db"


### PR DESCRIPTION
# Problem
Need to have a database setup for helm

# Solution
Setup databse in helm to include a pgbouncer sidecar alongside the app, and to keep the password in secrets has required some changes to how we process env vars for database context.

# Testing
Tested via local Kubernetes deployment
